### PR TITLE
Modify the calculation of reconstruction cost

### DIFF
--- a/TheanoDL/grbm.py
+++ b/TheanoDL/grbm.py
@@ -51,5 +51,5 @@ class GBRBM(RBM):
 
         """
 
-        rms_cost = T.mean(T.sum((self.input -  pre_sigmoid_nv)** 2))
+        rms_cost = T.mean(T.sum((self.input -  pre_sigmoid_nv)** 2, axis=1))
         return rms_cost


### PR DESCRIPTION
Follow the way in RBM calculation of reconstruction cost. Without axis input, T.sum(*) is already a scalar.
